### PR TITLE
Set up Turbo monorepo build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 # misc
 .DS_Store
 .env*
+tsconfig.tsbuildinfo
 
 # debug
 npm-debug.log*

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ yarn-error.log*
 /.vscode/*
 !/.vscode/settings.json
 !/.vscode/extensions.json
+
+# turbo
+.turbo

--- a/next.config.js
+++ b/next.config.js
@@ -8,12 +8,8 @@ const withSourceMaps = require('@zeit/next-source-maps');
 const webpackConfig = require('./webpack.config');
 const packageJson = require('./package.json');
 
-const date = new Date();
-
 module.exports = withSourceMaps({
   env: {
-    BUILD_TIME: date.toString(),
-    BUILD_TIMESTAMP: +date,
     APP_NAME: packageJson.name,
     APP_VERSION: packageJson.version,
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "nextjs-boilerplate",
   "version": "2.0.0",
+  "packageManager": "pnpm@10.33.0",
   "license": "ISC",
   "scripts": {
     "dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "stylelint-config-sass-guidelines": "^8.0.0",
     "stylelint-prettier": "^1.2.0",
     "stylelint-scss": "^3.19.0",
+    "turbo": "^2.9.12",
     "typescript": "^4.3.5"
   },
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,6 +117,9 @@ importers:
       stylelint-scss:
         specifier: ^3.19.0
         version: 3.21.0(stylelint@13.13.1)
+      turbo:
+        specifier: ^2.9.12
+        version: 2.9.12
       typescript:
         specifier: ^4.3.5
         version: 4.9.5
@@ -647,6 +650,36 @@ packages:
   '@tootallnate/once@1.1.2':
     resolution: {integrity: sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==}
     engines: {node: '>= 6'}
+
+  '@turbo/darwin-64@2.9.12':
+    resolution: {integrity: sha512-eu3eFRmE9NjgZ0wPdRJ44l+LGSeIky+tz5ZQd8zQkw/Yqi+BM7wq+8nbabeoiVUcICi/IZweMOKl/MCmkrd1+g==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@turbo/darwin-arm64@2.9.12':
+    resolution: {integrity: sha512-RUkAE404z/J8NsyrUosMcBaXT6M4bRFxTQrmkDQBLQVXaC8Jl0e9bMvYDSX0GW7Ffm2m3j9y7RXgR1foeUAM9w==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@turbo/linux-64@2.9.12':
+    resolution: {integrity: sha512-InIUtH7cw/vqXNX1Gr7QgWfmw3ct08pV5CpfdEOR48z2u2rzdmpIuk00B/Q2xCb0PMWtKgiMQynfuphmEuUyTQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@turbo/linux-arm64@2.9.12':
+    resolution: {integrity: sha512-lC6nD//Xh67fmJM0LKaLsg74Wry0aYrgMklpiNgCbUaMdPIOqj0A00iri3NU7Lb7pZHx8ViisgpeDKlpSgFUCA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@turbo/windows-64@2.9.12':
+    resolution: {integrity: sha512-conYri8VUl72JOdYnLDPYwzqbPcY5ECoHmo9FWoKznemhaAIilj4maHqs9Uar0aKfNoZIULniy+6iWaLtLO34A==}
+    cpu: [x64]
+    os: [win32]
+
+  '@turbo/windows-arm64@2.9.12':
+    resolution: {integrity: sha512-XoR4bsg62/L/esRVcmoMESEiNZ36+YmyjYGLpoqk8nwMgXzzVjNOgX0lRSz5w/U/ajLGv3nhMsS0Q2QOdvp2AQ==}
+    cpu: [arm64]
+    os: [win32]
 
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
@@ -3132,6 +3165,10 @@ packages:
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
 
+  turbo@2.9.12:
+    resolution: {integrity: sha512-lCPgus1NuTiBdaITWqzSH/Ff6HVL8HHGBtOXHg1dHRfcshN79XkygSdh0M6g8b0td91ILLG5MTkLOkp5UvyPJw==}
+    hasBin: true
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -3968,6 +4005,24 @@ snapshots:
       - '@types/react'
 
   '@tootallnate/once@1.1.2': {}
+
+  '@turbo/darwin-64@2.9.12':
+    optional: true
+
+  '@turbo/darwin-arm64@2.9.12':
+    optional: true
+
+  '@turbo/linux-64@2.9.12':
+    optional: true
+
+  '@turbo/linux-arm64@2.9.12':
+    optional: true
+
+  '@turbo/windows-64@2.9.12':
+    optional: true
+
+  '@turbo/windows-arm64@2.9.12':
+    optional: true
 
   '@types/aria-query@5.0.4': {}
 
@@ -7041,6 +7096,15 @@ snapshots:
     dependencies:
       tslib: 1.14.1
       typescript: 4.9.5
+
+  turbo@2.9.12:
+    optionalDependencies:
+      '@turbo/darwin-64': 2.9.12
+      '@turbo/darwin-arm64': 2.9.12
+      '@turbo/linux-64': 2.9.12
+      '@turbo/linux-arm64': 2.9.12
+      '@turbo/windows-64': 2.9.12
+      '@turbo/windows-arm64': 2.9.12
 
   type-check@0.4.0:
     dependencies:

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://turborepo.dev/schema.json",
+  "ui": "tui",
+  "tasks": {
+    "build": {
+      "inputs": ["$TURBO_DEFAULT$", ".env*"],
+      "outputs": [".next/**", "!.next/cache/**"]
+    },
+    "test": {
+      "outputs": ["coverage/**"]
+    },
+    "type-check": {},
+    "lint:scripts": {},
+    "lint:styles": {},
+    "lint": {},
+    "lint:fix": {},
+    "dev": {
+      "cache": false,
+      "persistent": true
+    },
+    "start": {
+      "cache": false,
+      "persistent": true
+    }
+  }
+}


### PR DESCRIPTION
## Summary
This PR introduces Turbo as the build orchestration system for the project, enabling better task caching and parallel execution in a monorepo environment.

## Key Changes
- **Added turbo.json**: Configured Turbo with task definitions for build, test, type-check, lint, dev, and start commands. Build outputs are cached while dev and start tasks are marked as persistent and non-cacheable.
- **Updated package.json**: 
  - Added `turbo@^2.9.12` as a dev dependency
  - Specified `pnpm@10.33.0` as the required package manager
- **Cleaned up next.config.js**: Removed dynamic `BUILD_TIME` and `BUILD_TIMESTAMP` environment variables that were being set at build time, keeping only static `APP_NAME` and `APP_VERSION` from package.json
- **Updated .gitignore**: Added entries for `.turbo/` cache directory and `tsconfig.tsbuildinfo` file

## Implementation Details
- The Turbo configuration uses the TUI (terminal UI) for better visibility
- Build task caches `.next/**` output while excluding `.next/cache/**`
- Test task caches coverage reports
- Dev and start tasks are configured as persistent to maintain state across runs
- The removal of dynamic build timestamps simplifies the build process and improves cacheability

https://claude.ai/code/session_016iAFMido19urT6BMdhp3WQ